### PR TITLE
Remove filmmaker subtitle from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,10 +21,9 @@
 </head>
 <body class="index-page">
 
-    <!-- Persistent Header with Name and Filmmaker Title -->
+    <!-- Persistent Header with Name -->
      <header class="persistent-header">
         <h1 class="main-title">Miguel Guzman</h1>
-        <p class="sub-title">Filmmaker</p>
     </header>
 
 


### PR DESCRIPTION
## Summary
- remove `Filmmaker` subtitle from homepage header

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684155960d1c832caf286045ac7609f7