### PR TITLE
Fix menu text color in Screening page

### DIFF
--- a/Screening.html
+++ b/Screening.html
@@ -68,10 +68,6 @@
     .tickets-btn:hover { opacity: 0.9; }
     .card4 .disclaimer { position: absolute; bottom: 20px; left: 20px; right: 20px; text-align: center; font-size: 0.8em; padding: 0 20px; z-index: 1; }
 
-    .white-menu,
-    .white-menu a {
-      color: #fff;
-    }
 
     /* Mobile tweaks */
     @media (max-width: 480px) {
@@ -86,7 +82,7 @@
   </style>
 </head>
 <body>
-  <div id="menu-container"  class="white-menu"></div>
+  <div id="menu-container"></div>
   <div class="card card1">
     <p class="title">ONEIRA</p>
     <p class="screening">Family and friends screening</p>


### PR DESCRIPTION
## Summary
- remove `white-menu` styling from `Screening.html`
- use default menu text color

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ad5eee484832c89d34cd71a553a5a